### PR TITLE
support despawning octree pointcloud

### DIFF
--- a/src/octree/extract/mod.rs
+++ b/src/octree/extract/mod.rs
@@ -119,6 +119,7 @@ where
             .add_systems(
                 ExtractSchedule,
                 (
+                    cleanup_render_octree_index::<E>.before(extract_visible_octree_nodes::<E>),
                     extract_visible_octree_nodes::<E>.after(extract_cameras),
                     extract_render_octree_nodes::<E, A>.after(extract_visible_octree_nodes::<E>),
                 ),
@@ -166,7 +167,6 @@ impl<C: Component> FromWorld for RenderOctreeIndex<C> {
 impl<C: Component> RenderOctreeIndex<C> {
     /// Add octree entity to index, if it already exists, does nothing.
     pub fn add_octree(&mut self, entity: Entity) -> usize {
-        // TODO cleanup old octrees from the slab (if removed ?)
         *self
             .octrees_index
             .entry(entity)
@@ -186,6 +186,29 @@ impl<C: Component> RenderOctreeIndex<C> {
     pub fn get_octree_index(&self, entity: Entity) -> Option<usize> {
         self.octrees_index.get(&entity).copied()
     }
+}
+
+/// This system removes despawned octree entities from [`RenderOctreeIndex`].
+/// It runs before [`extract_visible_octree_nodes`] to ensure the slab indices stay consistent
+/// with the number of currently active octrees, preventing out-of-bounds buffer accesses.
+pub fn cleanup_render_octree_index<E: OctreeNodeExtraction>(
+    mut render_octree_index: ResMut<RenderOctreeIndex<E::Component>>,
+    active_entities: Query<Entity, With<E::Component>>,
+) {
+    let RenderOctreeIndex {
+        octrees_index,
+        octrees_slab,
+        ..
+    } = &mut *render_octree_index;
+
+    octrees_index.retain(|&entity, &mut index| {
+        if active_entities.get(entity).is_ok() {
+            true
+        } else {
+            octrees_slab.remove(index);
+            false
+        }
+    });
 }
 
 /// This system extracts computed visible octree nodes and add them in the render world, for each view (camera)

--- a/src/octree/server/mod.rs
+++ b/src/octree/server/mod.rs
@@ -379,8 +379,11 @@ pub fn handle_internal_octree_events<T>(
                 load_tasks.hierarchy_in_flight.remove(&key);
 
                 let Some(octree) = assets.get_mut(id) else {
-                    warn!(
-                        "No asset found for {:?}, unable to append loaded hierarchy nodes.",
+                    // Asset was evicted or despawned; clean up loader so no further
+                    // tasks are scheduled for this dead asset.
+                    server.loaders.remove(&id);
+                    debug!(
+                        "No asset found for {:?}, discarding loaded hierarchy nodes (likely asset evicted).",
                         id
                     );
                     continue;
@@ -463,13 +466,15 @@ pub fn handle_internal_octree_events<T>(
                 load_tasks.node_in_flight.remove(&key);
 
                 let Some(octree) = assets.get_mut(id) else {
-                    warn!("No asset found for {:?}, unable to store node data.", id);
+                    // Asset was evicted or despawned; clean up loader.
+                    server.loaders.remove(&id);
+                    debug!("No asset found for {:?}, discarding node data (likely asset evicted).", id);
                     continue;
                 };
 
                 if let Err(error) = octree.insert_node_data(node_id, node_data) {
                     warn!(
-                        "An error occured when adding node data to node {}/{:?}: {:#}",
+                        "An error occurred when adding node data to node {}/{:?}: {:#}",
                         id, node_id, error
                     );
                     continue;

--- a/src/octree/server/process.rs
+++ b/src/octree/server/process.rs
@@ -62,7 +62,7 @@ fn process_hierarchy_loads<T>(
         }
 
         let Some(octree) = octree_assets.get_mut(task.asset_id) else {
-            warn!("Octree asset not found: {:?}", task.asset_id);
+            debug!("Octree asset not found: {:?}, skipping (likely evicted)", task.asset_id);
             continue;
         };
 
@@ -80,7 +80,7 @@ fn process_hierarchy_loads<T>(
 
         // Spawn load sub hierarchy task
         if let Err(error) = server.load_sub_hierarchy(task.asset_id, octree, task.node_id) {
-            warn!("An error occured loading node hierarchy: {:#} ", error);
+            warn!("An error occurred loading node hierarchy: {:#} ", error);
             continue;
         }
 
@@ -119,7 +119,7 @@ fn process_node_data_loads<T>(
         }
 
         let Some(octree) = octree_assets.get_mut(task.asset_id) else {
-            warn!("Octree asset not found: {:?}", task.asset_id);
+            debug!("Octree asset not found: {:?}, skipping (likely evicted)", task.asset_id);
             continue;
         };
 
@@ -137,7 +137,7 @@ fn process_node_data_loads<T>(
 
         // Spawn load sub hierarchy task
         if let Err(error) = server.load_node_data(task.asset_id, octree, task.node_id) {
-            warn!("An error occured loading node data: {:#} ", error);
+            warn!("An error occurred loading node data: {:#} ", error);
             continue;
         }
 

--- a/src/octree/visibility/mod.rs
+++ b/src/octree/visibility/mod.rs
@@ -38,11 +38,11 @@ use std::marker::PhantomData;
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CheckOctreeNodesVisibility;
 
-pub struct OctreeVisiblityPlugin<T, C, F = ScreenPixelRadiusFilter, B = ()>(
+pub struct OctreeVisibilityPlugin<T, C, F = ScreenPixelRadiusFilter, B = ()>(
     PhantomData<fn() -> (T, C, F, B)>,
 );
 
-impl<T, C, F, B> OctreeVisiblityPlugin<T, C, F, B> {
+impl<T, C, F, B> OctreeVisibilityPlugin<T, C, F, B> {
     /// Visibility check diagnostic
     pub const VISIBILITY_CHECK_TIME: DiagnosticPath =
         DiagnosticPath::const_new("pcl_octree_visibility_check");
@@ -51,12 +51,12 @@ impl<T, C, F, B> OctreeVisiblityPlugin<T, C, F, B> {
     pub const BUDGET: DiagnosticPath = DiagnosticPath::const_new("pcl_octree_budget");
 }
 
-impl<T, C, F, B> Default for OctreeVisiblityPlugin<T, C, F, B> {
+impl<T, C, F, B> Default for OctreeVisibilityPlugin<T, C, F, B> {
     fn default() -> Self {
-        OctreeVisiblityPlugin(PhantomData)
+        OctreeVisibilityPlugin(PhantomData)
     }
 }
-impl<T, C, F, B> Plugin for OctreeVisiblityPlugin<T, C, F, B>
+impl<T, C, F, B> Plugin for OctreeVisibilityPlugin<T, C, F, B>
 where
     T: NodeData,
     C: Component,
@@ -153,8 +153,11 @@ pub fn check_octree_nodes_visibility<T, C, F, B>(
             continue;
         }
 
-        // Reset previously computed visibility
+        // Reset previously computed visibility, and remove entries for despawned entities
         visible_octree_nodes.clear_all();
+        visible_octree_nodes
+            .octrees
+            .retain(|entity, _| entities.get(*entity).is_ok());
 
         let camera_view = CameraView {
             global_transform: camera_global_transform,
@@ -255,14 +258,14 @@ pub fn check_octree_nodes_visibility<T, C, F, B>(
             &mut octree_load_tasks,
         );
 
-        diagnostics.add_measurement(&OctreeVisiblityPlugin::<T, C, B>::BUDGET, || budget.value());
+        diagnostics.add_measurement(&OctreeVisibilityPlugin::<T, C, B>::BUDGET, || budget.value());
     }
 
     let duration = start.elapsed();
     let msecs = duration.as_secs_f64() * 1000.0;
 
     diagnostics.add_measurement(
-        &OctreeVisiblityPlugin::<T, C, B>::VISIBILITY_CHECK_TIME,
+        &OctreeVisibilityPlugin::<T, C, B>::VISIBILITY_CHECK_TIME,
         || msecs,
     );
 }
@@ -383,7 +386,7 @@ fn compute_visible_nodes_stack<'a, T, C, F, B>(
                 continue;
             }
 
-            // Check if the aabb is completly inside the frustum
+            // Check if the aabb is completely inside the frustum
             if camera_view
                 .frustum
                 .contains_aabb(&node.hierarchy.bounding_box, &world_from_local)

--- a/src/pointcloud_octree/mod.rs
+++ b/src/pointcloud_octree/mod.rs
@@ -9,7 +9,7 @@ use crate::octree::extract::ExtractVisibleOctreeNodesPlugin;
 use crate::octree::server::{OctreeServer, OctreeServerPlugin};
 use crate::octree::visibility::components::OctreeVisibilitySettings;
 use crate::octree::visibility::filter::ScreenPixelRadiusFilter;
-use crate::octree::visibility::OctreeVisiblityPlugin;
+use crate::octree::visibility::OctreeVisibilityPlugin;
 use crate::octree::OctreeAssetPlugin;
 use crate::pointcloud_octree::asset::data::PointCloudNodeData;
 use crate::pointcloud_octree::extract::RenderPointCloudNodeData;
@@ -20,7 +20,7 @@ use component::PointCloudOctree3d;
 
 pub type PointCloudOctreeAssetPlugin = OctreeAssetPlugin<PointCloudNodeData>;
 
-pub type PointCloudOctreeVisibilityPlugin = OctreeVisiblityPlugin<
+pub type PointCloudOctreeVisibilityPlugin = OctreeVisibilityPlugin<
     PointCloudNodeData,
     PointCloudOctree3d,
     ScreenPixelRadiusFilter,

--- a/src/pointcloud_octree/render/phase.rs
+++ b/src/pointcloud_octree/render/phase.rs
@@ -221,7 +221,7 @@ where
             &VisibleNodesTextureBindGroup,
         )>()
         else {
-            warn!("Unable to get view components");
+            // VisibleNodesTextureBindGroup is absent during startup or when no octrees are active
             return Ok(());
         };
 

--- a/src/pointcloud_octree/render/prepare.rs
+++ b/src/pointcloud_octree/render/prepare.rs
@@ -120,7 +120,12 @@ pub fn prepare_visible_nodes_texture(
             continue;
         }
 
-        let required_buffer_size = octrees_count * MAX_NODES;
+        // Use slab capacity (not len) for sizing: after entity removal, surviving entities
+        // retain their original slab indices (e.g. index 1 stays 1 even if index 0 was freed),
+        // so buffers and textures must accommodate the full allocated slot range.
+        let slot_count = render_octree_index.octrees_slab.capacity();
+
+        let required_buffer_size = slot_count * MAX_NODES;
 
         // prepare the buffer only once
         if visible_nodes_buffer.len() < required_buffer_size {
@@ -138,7 +143,7 @@ pub fn prepare_visible_nodes_texture(
             // The size of the depth texture
             let size = Extent3d {
                 width: MAX_NODES as u32, // max 2048 nodes per octree visible at the same time
-                height: octrees_count as u32, // max 64 octrees visibles at the same time
+                height: slot_count as u32, // one row per allocated octree slot
                 depth_or_array_layers: 1,
             };
 
@@ -157,7 +162,7 @@ pub fn prepare_visible_nodes_texture(
         };
 
         let mut node_index =
-            vec![HashMap::<NodeId, u32>::default(); render_octree_index.octrees_slab.len()];
+            vec![HashMap::<NodeId, u32>::default(); slot_count];
 
         'main_loop: for (entity, (asset_id, octree_nodes)) in &visible_nodes.octrees {
             let octree_index = render_octree_index
@@ -247,15 +252,15 @@ pub fn prepare_visible_nodes_texture(
 
         render_queue.write_texture(
             visible_nodes_texture.texture.as_image_copy(),
-            bytemuck::cast_slice(&visible_nodes_buffer),
+            bytemuck::cast_slice(&visible_nodes_buffer[..slot_count * MAX_NODES]),
             TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some((MAX_NODES * 4) as u32), // 4 bytes par texel RGBA8Uint
-                rows_per_image: Some(octrees_count as u32),
+                rows_per_image: Some(slot_count as u32),
             },
             Extent3d {
                 width: MAX_NODES as u32,
-                height: octrees_count as u32,
+                height: slot_count as u32,
                 depth_or_array_layers: 1,
             },
         );


### PR DESCRIPTION
Previously, despawning a pointcloud will mess with the index in such a way that it will eventually lead to a crash.

This is what the log might looks like:
```log
2026-02-28T13:22:34.865337Z  WARN bevy_pointcloud::octree::extract: Render entity for PointCloudOctree3d not found
2026-02-28T13:22:34.865352Z  WARN bevy_pointcloud::octree::extract: Render entity for PointCloudOctree3d not found
2026-02-28T13:22:34.865362Z  WARN bevy_pointcloud::octree::extract: Query item not found when extracting octree nodes: 18v0
2026-02-28T13:22:34.865369Z  WARN bevy_pointcloud::octree::extract: Query item not found when extracting octree nodes: 21v0
2026-02-28T13:22:34.866036Z  INFO bevy_pointcloud::octree::server: Loaded octree AssetId<bevy_pointcloud::octree::asset::Octree<bevy_pointcloud::pointcloud_octree::asset::data::PointCloudNodeData>>{ index: 0, generation: 1}
2026-02-28T13:22:34.907206Z  WARN bevy_pointcloud::octree::extract: Render entity for PointCloudOctree3d not found
2026-02-28T13:22:34.907225Z  WARN bevy_pointcloud::octree::extract: Render entity for PointCloudOctree3d not found
2026-02-28T13:22:34.907236Z  WARN bevy_pointcloud::octree::extract: Query item not found when extracting octree nodes: 18v0
2026-02-28T13:22:34.907244Z  WARN bevy_pointcloud::octree::extract: Query item not found when extracting octree nodes: 21v0
2026-02-28T13:22:34.948889Z  WARN bevy_pointcloud::octree::extract: Render entity for PointCloudOctree3d not found
2026-02-28T13:22:34.948905Z  WARN bevy_pointcloud::octree::extract: Render entity for PointCloudOctree3d not found
2026-02-28T13:22:34.948916Z  WARN bevy_pointcloud::octree::extract: Query item not found when extracting octree nodes: 18v0
2026-02-28T13:22:34.949023Z  WARN bevy_pointcloud::octree::extract: Query item not found when extracting octree nodes: 21v0

thread 'Compute Task Pool (7)' (78554) panicked at src/pointcloud_octree/render/prepare.rs:238:37:
index out of bounds: the len is 4096 but the index is 4096
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_pointcloud::pointcloud_octree::render::prepare::prepare_visible_nodes_texture`!
```

-----

# after this PR

- Adds a cleanup system to clear the despawning entity's octree nodes
- We retain their original slab indices (e.g. index 1 stays 1 even if index 0 was freed, after despawning an octree),
- Converts some of the **warn** log to **debug** log, as some checks become a "normal" code path on the first frame after an octree is just despawned (otherwise it will spam the log after despawning an octree)
- some typo fixes

https://github.com/user-attachments/assets/370a5a13-716f-4681-9ac2-48dd888e29a9

